### PR TITLE
Fixed $d highlight

### DIFF
--- a/syntaxes/metamath.tmLanguage.json
+++ b/syntaxes/metamath.tmLanguage.json
@@ -13,7 +13,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.metamath",
-				"match": "\\$(a|c|e|f|p|v|\\.|{|}|=)"
+				"match": "\\$(a|c|e|f|p|v|d|\\.|{|}|=)"
 			}]
 		},
 		"comments": {


### PR DESCRIPTION
The keyword `$d` for disjoint variable condition doesn't get highlighted, so I added it.